### PR TITLE
[documentation] Favor QT_QPA_PLATFORM over -platform. Fixes JB#48639

### DIFF
--- a/doc/src/sdk-user-manual-noninteractive.qdoc
+++ b/doc/src/sdk-user-manual-noninteractive.qdoc
@@ -67,8 +67,9 @@ maintenance.
         \endlist
 \endtable
 
-Execution on a headless system is possible with the help of the standard Qt
-option \c {-platform minimal}, likely in combination with \c --verbose.
+Execution on a headless system is possible with the help of the
+\c QT_QPA_PLATFORM environment variable. Set \c QT_QPA_PLATFORM=minimal in the
+environment to achieve headless execution.
 
 Examples follows.
 


### PR DESCRIPTION
Qt IFW is verbose about the -platform option.